### PR TITLE
[DEVOPS-7128]: switch to external-containers synced

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: us-docker.pkg.dev/labelbox-artifacts/external-container/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
kubebuilder https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/discontinue_usage_of_kube_rbac_proxy.md points to that registry suggestion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the deployed `kube-rbac-proxy` container image source; misconfigured registry access or image mismatch could break controller metrics/auth proxy startup.
> 
> **Overview**
> Updates the controller manager auth-proxy sidecar to pull `kube-rbac-proxy:v0.8.0` from the `us-docker.pkg.dev/labelbox-artifacts/external-container` mirror instead of `gcr.io/kubebuilder`, keeping the version and runtime args unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6fe5b81700b73ab83e881bc9245b7b3ca06e190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->